### PR TITLE
Development

### DIFF
--- a/server.R
+++ b/server.R
@@ -146,8 +146,23 @@ shinyServer(function(input, output, clientData, session) {#reactive shiny functi
     
     data
   })
+
+  # A reactive data item that is used to control the height of the raw data and trend
+  # plot.  The height is computed based on the width - it the plot is not as high
+  # as it is wide, and if the width exceeds a minimum, then the height catches up with
+  # the width to make a square plot.
   
-  # Draw the plot of input data or selected trend test
+  DTP_height <- reactive({
+    Width <- session$clientData$output_DataAndTrendPlot_width
+    Height <- session$clientData$output_DataAndTrendPlot_height
+    if((Width > Height) && (Width > 400)) {
+      Height <- Width
+    }
+    Height
+  })
+  
+  # Draw the plot of input data or selected trend test.  The height is controlled by the
+  # reactive data item specified above.
   
   output$DataAndTrendPlot <- renderPlot({ #reactive function, basically Main()
     
@@ -178,7 +193,7 @@ shinyServer(function(input, output, clientData, session) {#reactive shiny functi
 
       #plot(data) Leave this here to use if ggplot() stops working. 
     }
-  })
+  }, height=DTP_height)
   
   
   # Download handler for saving data and trend plots or tables.

--- a/ui.R
+++ b/ui.R
@@ -91,7 +91,7 @@ shinyUI(navbarPage("Software Reliability Assessment in R",
                               
                               mainPanel(
                                 tabsetPanel(
-                                  tabPanel("Plot", textOutput("InputFileError"), textOutput("DataSubsetError"), plotOutput("DataAndTrendPlot",height="700px")), 
+                                  tabPanel("Plot", textOutput("InputFileError"), textOutput("DataSubsetError"), plotOutput("DataAndTrendPlot")), 
                                   tabPanel("Data and Trend Test Table", dataTableOutput("dataAndTrendTable")),
                                   id="DataPlotAndTableTabset"),
                                 width=8


### PR DESCRIPTION
Added half-baked way of autosizing the data and trend test plots by reading in the plot width as a reactive data item and basing the plot height on the current width.  It's not as nice as a true autosizing, but it works well enough.  I used this because the "height=auto" setting doesn't work properly for ggplot.